### PR TITLE
Add tmux config with per-pane git info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Helpers
+
+## Tmux Setup
+
+Tmux config with per-pane git branch/worktree display.
+
+```shell
+ln -sf ~/Helpers/tmux/.tmux.conf ~/.tmux.conf
+```
+
+Reload an existing tmux session:
+
+```shell
+tmux source-file ~/.tmux.conf
+```
+
 # Git Helpers
 
 ## Git config updates

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,0 +1,29 @@
+# Set prefix to Ctrl-Space
+unbind C-b
+set -g prefix C-Space
+bind C-Space send-prefix
+
+# Active pane stands out clearly
+set -g pane-active-border-style "fg=cyan,bold"
+set -g pane-border-style "fg=colour238"
+
+# Dim inactive panes more aggressively
+set -g window-style "fg=colour245,bg=colour236"
+set -g window-active-style "fg=white,bg=black"
+
+# Status bar - active window stands out
+set -g status-style "bg=colour235,fg=colour248"
+set -g window-status-format " #I:#W "
+set -g window-status-current-format " #I:#W "
+set -g window-status-current-style "bg=cyan,fg=black,bold"
+set -g window-status-style "bg=colour235,fg=colour245"
+
+# Show git branch/worktree in pane border
+set -g pane-border-status top
+set -g pane-border-format " #($HOME/config/tmux/pane-git-info.sh #{pane_current_path}) "
+
+# Vim-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R

--- a/tmux/pane-git-info.sh
+++ b/tmux/pane-git-info.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd "$1" || exit 0
+b=$(git branch --show-current 2>/dev/null) || exit 0
+tl=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+echo "$(basename "$tl") [$b]"


### PR DESCRIPTION
## Summary
- Adds tmux configuration with custom prefix, pane styling, and vim-style navigation
- Includes helper script that displays current git branch and worktree directory in each pane border

## Test plan
- [ ] Symlink `~/.tmux.conf` to `Helpers/tmux/.tmux.conf`
- [ ] Reload tmux and verify pane borders show `directory [branch]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)